### PR TITLE
fix: resolve merge conflict markers from PR #5 merge (NG-5)

### DIFF
--- a/lua/mermaid/panel.lua
+++ b/lua/mermaid/panel.lua
@@ -1,141 +1,136 @@
-     1|--- mermaid panel: Neovim floating window for preview controls
-     2|--
-     3|-- Shows: preview URL, renderer info, connection status, quick actions.
-     4|-- Auto-opens when :MermaidPreview is called.
-     5|local M = {}
-     6|
-     7|local namespace = vim.api.nvim_create_namespace("mermaid_panel")
-     8|local buf = nil
-     9|local win = nil
-    10|
-    11|local STATUS_SYMBOLS = {
-    12|  connected    = "●",
-    13|  disconnected = "○",
-    14|  reconnecting = "◌",
-    15|  stopped      = "×",
-    16|}
-    17|
-    18|--- Window dimensions (relative to editor)
-    19|local WIN_WIDTH = 44
-    20|local WIN_HEIGHT = 10
-    21|
-    22|--- Re-render the panel content
-    23|local function refresh()
-    24|  if not buf or not vim.api.nvim_buf_is_valid(buf) then return end
-    25|
-    26|  local server = require("mermaid.server")
-    27|  local port = server.port or "—"
-    28|  local url = port ~= "—" and ("http://localhost:" .. port) or "not running"
-    29|  local renderer = require("mermaid").config.preview.renderer or "mermaid.js"
-    30|<<<<<<< HEAD
-    31|  local theme_mode = server.get_effective_theme_mode() or "light"
-    32|=======
-    33|  local theme_mode = server.theme_mode or "light"
-    34|>>>>>>> origin/main
-    35|  local client_count = 0
-    36|  for _, _ in pairs(server.clients or {}) do client_count = client_count + 1 end
-    37|  local status = server.server and "connected" or "stopped"
-    38|  local status_sym = STATUS_SYMBOLS[status] or "?"
-    39|
-    40|  local lines = {
-    41|    "  🧜 Mermaid Preview",
-    42|    "",
-    43|    "  " .. status_sym .. "  Status:      " .. status,
-    44|    "  🔗  URL:         " .. url,
-    45|    "  🎨  Renderer:    " .. renderer,
-    46|    "  🌓  Theme:       " .. theme_mode,
-    47|    "  👥  Clients:     " .. client_count,
-    48|    "",
-    49|    "  [o] Open browser  [c] Copy URL  [q] Close",
-    50|  }
-    51|
-    52|  -- Temporarily allow modification for buffer updates
-    53|  local was_modifiable = vim.api.nvim_buf_get_option(buf, "modifiable")
-    54|  vim.api.nvim_buf_set_option(buf, "modifiable", true)
-    55|  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
-    56|  if not was_modifiable then
-    57|    vim.api.nvim_buf_set_option(buf, "modifiable", false)
-    58|  end
-    59|
-    60|  -- Highlight header
-    61|  vim.api.nvim_buf_clear_namespace(buf, namespace, 0, -1)
-    62|  vim.api.nvim_buf_add_highlight(buf, namespace, "Title", 0, 2, #lines[1])
-    63|end
-    64|
-    65|--- Create the floating window
-    66|function M.open(_url)
-    67|  -- Close existing panel first
-    68|  M.close()
-    69|
-    70|  -- Calculate position (top-right corner)
-    71|  local uis = vim.api.nvim_list_uis()
-    72|  local ui = uis and uis[1]
-    73|  if not ui then
-    74|    -- Headless mode or no UI: silently skip
-    75|    return
-    76|  end
-    77|  local row = 1
-    78|  local col = math.max(0, ui.width - WIN_WIDTH - 1)
-    79|
-    80|  buf = vim.api.nvim_create_buf(false, true)
-    81|  win = vim.api.nvim_open_win(buf, false, {
-    82|    relative = "editor",
-    83|    width = WIN_WIDTH,
-    84|    height = WIN_HEIGHT,
-    85|    row = row,
-    86|    col = col,
-    87|    style = "minimal",
-    88|    border = "rounded",
-    89|    title = " mermaid.nvim ",
-    90|    title_pos = "center",
-    91|  })
-    92|
-    93|  vim.api.nvim_win_set_option(win, "winhl", "Normal:NormalFloat,FloatBorder:FloatBorder")
-    94|  vim.api.nvim_buf_set_option(buf, "buftype", "nofile")
-    95|
-    96|  refresh()
-    97|
-    98|  vim.api.nvim_buf_set_option(buf, "modifiable", false)
-    99|  vim.api.nvim_buf_set_keymap(buf, "n", "o", ":MermaidPreview<CR>", { noremap = true, silent = true })
-   100|  vim.api.nvim_buf_set_keymap(buf, "n", "c", ":call MermaidCopyURL()<CR>", { noremap = true, silent = true })
-   101|  vim.api.nvim_buf_set_keymap(buf, "n", "q", ":lua require('mermaid.panel').close()<CR>", { noremap = true, silent = true })
-   102|end
-   103|
-   104|--- Update panel content (called periodically or on state changes)
-   105|function M.update()
-   106|  refresh()
-   107|end
-   108|
-   109|--- Close the floating window
-   110|function M.close()
-   111|  if win and vim.api.nvim_win_is_valid(win) then
-   112|    vim.api.nvim_win_close(win, true)
-   113|  end
-   114|  if buf and vim.api.nvim_buf_is_valid(buf) then
-   115|    vim.api.nvim_buf_delete(buf, { force = true })
-   116|  end
-   117|  win = nil
-   118|  buf = nil
-   119|end
-   120|
-   121|--- Check if the panel is currently open
-   122|function M.is_open()
-   123|  return win ~= nil and vim.api.nvim_win_is_valid(win)
-   124|end
-   125|
-   126|--- Set up a timer to refresh the panel periodically
-   127|local refresh_timer = nil
-   128|function M.start_auto_refresh()
-   129|  if refresh_timer then return end
-   130|  refresh_timer = vim.defer_fn(function()
-   131|    if M.is_open() then
-   132|      refresh()
-   133|      M.start_auto_refresh()
-   134|    else
-   135|      refresh_timer = nil
-   136|    end
-   137|  end, 2000)
-   138|end
-   139|
-   140|return M
-   141|
+--- mermaid panel: Neovim floating window for preview controls
+--
+-- Shows: preview URL, renderer info, connection status, quick actions.
+-- Auto-opens when :MermaidPreview is called.
+local M = {}
+
+local namespace = vim.api.nvim_create_namespace("mermaid_panel")
+local buf = nil
+local win = nil
+
+local STATUS_SYMBOLS = {
+  connected    = "●",
+  disconnected = "○",
+  reconnecting = "◌",
+  stopped      = "×",
+}
+
+--- Window dimensions (relative to editor)
+local WIN_WIDTH = 44
+local WIN_HEIGHT = 10
+
+--- Re-render the panel content
+local function refresh()
+  if not buf or not vim.api.nvim_buf_is_valid(buf) then return end
+
+  local server = require("mermaid.server")
+  local port = server.port or "—"
+  local url = port ~= "—" and ("http://localhost:" .. port) or "not running"
+  local renderer = require("mermaid").config.preview.renderer or "mermaid.js"
+  local theme_mode = server.get_effective_theme_mode() or "light"
+  local client_count = 0
+  for _, _ in pairs(server.clients or {}) do client_count = client_count + 1 end
+  local status = server.server and "connected" or "stopped"
+  local status_sym = STATUS_SYMBOLS[status] or "?"
+
+  local lines = {
+    "  🧜 Mermaid Preview",
+    "",
+    "  " .. status_sym .. "  Status:      " .. status,
+    "  🔗  URL:         " .. url,
+    "  🎨  Renderer:    " .. renderer,
+    "  🌓  Theme:       " .. theme_mode,
+    "  👥  Clients:     " .. client_count,
+    "",
+    "  [o] Open browser  [c] Copy URL  [q] Close",
+  }
+
+  -- Temporarily allow modification for buffer updates
+  local was_modifiable = vim.api.nvim_buf_get_option(buf, "modifiable")
+  vim.api.nvim_buf_set_option(buf, "modifiable", true)
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+  if not was_modifiable then
+    vim.api.nvim_buf_set_option(buf, "modifiable", false)
+  end
+
+  -- Highlight header
+  vim.api.nvim_buf_clear_namespace(buf, namespace, 0, -1)
+  vim.api.nvim_buf_add_highlight(buf, namespace, "Title", 0, 2, #lines[1])
+end
+
+--- Create the floating window
+function M.open(_url)
+  -- Close existing panel first
+  M.close()
+
+  -- Calculate position (top-right corner)
+  local uis = vim.api.nvim_list_uis()
+  local ui = uis and uis[1]
+  if not ui then
+    -- Headless mode or no UI: silently skip
+    return
+  end
+  local row = 1
+  local col = math.max(0, ui.width - WIN_WIDTH - 1)
+
+  buf = vim.api.nvim_create_buf(false, true)
+  win = vim.api.nvim_open_win(buf, false, {
+    relative = "editor",
+    width = WIN_WIDTH,
+    height = WIN_HEIGHT,
+    row = row,
+    col = col,
+    style = "minimal",
+    border = "rounded",
+    title = " mermaid.nvim ",
+    title_pos = "center",
+  })
+
+  vim.api.nvim_win_set_option(win, "winhl", "Normal:NormalFloat,FloatBorder:FloatBorder")
+  vim.api.nvim_buf_set_option(buf, "buftype", "nofile")
+
+  refresh()
+
+  vim.api.nvim_buf_set_option(buf, "modifiable", false)
+  vim.api.nvim_buf_set_keymap(buf, "n", "o", ":MermaidPreview<CR>", { noremap = true, silent = true })
+  vim.api.nvim_buf_set_keymap(buf, "n", "c", ":call MermaidCopyURL()<CR>", { noremap = true, silent = true })
+  vim.api.nvim_buf_set_keymap(buf, "n", "q", ":lua require('mermaid.panel').close()<CR>", { noremap = true, silent = true })
+end
+
+--- Update panel content (called periodically or on state changes)
+function M.update()
+  refresh()
+end
+
+--- Close the floating window
+function M.close()
+  if win and vim.api.nvim_win_is_valid(win) then
+    vim.api.nvim_win_close(win, true)
+  end
+  if buf and vim.api.nvim_buf_is_valid(buf) then
+    vim.api.nvim_buf_delete(buf, { force = true })
+  end
+  win = nil
+  buf = nil
+end
+
+--- Check if the panel is currently open
+function M.is_open()
+  return win ~= nil and vim.api.nvim_win_is_valid(win)
+end
+
+--- Set up a timer to refresh the panel periodically
+local refresh_timer = nil
+function M.start_auto_refresh()
+  if refresh_timer then return end
+  refresh_timer = vim.defer_fn(function()
+    if M.is_open() then
+      refresh()
+      M.start_auto_refresh()
+    else
+      refresh_timer = nil
+    end
+  end, 2000)
+end
+
+return M

--- a/lua/mermaid/render.lua
+++ b/lua/mermaid/render.lua
@@ -1,177 +1,166 @@
-     1|--- mermaid render: render diagrams inline in the terminal
-     2|--
-     3|-- Supports multiple terminal capabilities:
-     4|--   kitty:  Kitty terminal image protocol (icat)
-     5|--   chafa:  ASCII/ANSI art via chafa CLI
-     6|--   sixel:  Sixel graphics (if available)
-     7|--   none:   Fallback — no inline rendering
-     8|--
-     9|-- Detection logic:
-    10|--   1. Check $KITTY_WINDOW_ID for Kitty protocol
-    11|--   2. Check $TERM_PROGRAM for iTerm2
-    12|--   3. Check $TERM for "sixel" or "xterm" (best-effort)
-    13|--   4. Check if `chafa` is installed
-    14|--   5. Fallback to "none" (URL-only)
-    15|local M = {}
-    16|
-    17|--- Detect what terminal rendering capability is available
-    18|function M.detect_capability()
-    19|  local env = vim.fn.environ()
-    20|
-    21|  -- Kitty protocol (most reliable)
-    22|  if vim.fn.executable("kitty") == 1 and env["KITTY_WINDOW_ID"] ~= vim.NIL then
-    23|    return "kitty"
-    24|  end
-    25|
-    26|  -- iTerm2
-    27|  if env["TERM_PROGRAM"] == "iTerm.app" then
-    28|    return "iterm2"
-    29|  end
-    30|
-    31|  -- Sixel
-    32|  local term = env["TERM"] or ""
-    33|  if term:match("sixel") then
-    34|    return "sixel"
-    35|  end
-    36|
-    37|  -- chafa (universal ASCII/ANSI art)
-    38|  if vim.fn.executable("chafa") == 1 then
-    39|    return "chafa"
-    40|  end
-    41|
-    42|  -- No capability found
-    43|  return "none"
-    44|end
-    45|
-    46|--- Format a human-readable label for the capability
-    47|function M.capability_label(cap)
-    48|  local labels = {
-    49|    kitty  = "Kitty image protocol",
-    50|    iterm2 = "iTerm2 image protocol",
-    51|    sixel  = "Sixel graphics",
-    52|    chafa  = "chafa (ASCII/ANSI art)",
-    53|    none   = "None (URL only)",
-    54|  }
-    55|  return labels[cap] or "Unknown"
-    56|end
-    57|
-    58|--- Generate SVG using mmdc from Mermaid source text.
-    59|<<<<<<< HEAD
-    60|--- Theme is derived from Neovim's background setting for terminal render.
-    61|=======
-    62|>>>>>>> origin/main
-    63|--- Returns { ok = true, svg_path = "..." } or { ok = false, error = "..." }
-    64|function M.generate_svg(content, output_path)
-    65|  output_path = output_path or os.tmpname() .. ".svg"
-    66|
-    67|  local cmd = "mmdc"
-    68|  if vim.fn.executable(cmd) == 0 then
-    69|    return { ok = false, error = "mmdc not found. Install @mermaid-js/mermaid-cli." }
-    70|  end
-    71|
-    72|<<<<<<< HEAD
-    73|  -- Map Neovim background to mermaid theme: dark → "dark", light → "default"
-    74|  local mmdc_theme = vim.o.background == "dark" and "dark" or "default"
-    75|
-    76|=======
-    77|>>>>>>> origin/main
-    78|  local tmp_input = os.tmpname() .. ".mmd"
-    79|  local input_f = io.open(tmp_input, "w")
-    80|  if input_f then
-    81|    input_f:write(content)
-    82|    input_f:close()
-    83|  else
-    84|    return { ok = false, error = "Failed to write temp file" }
-    85|  end
-    86|
-    87|<<<<<<< HEAD
-    88|  local result = vim.fn.system({ cmd, "-i", tmp_input, "-o", output_path, "--theme", mmdc_theme })
-    89|=======
-    90|  local result = vim.fn.system({ cmd, "-i", tmp_input, "-o", output_path })
-    91|>>>>>>> origin/main
-    92|  local exit_code = vim.v.shell_error
-    93|
-    94|  pcall(os.remove, tmp_input)
-    95|
-    96|  if exit_code ~= 0 then
-    97|    pcall(os.remove, output_path)
-    98|    return { ok = false, error = "mmdc failed: " .. (result or "unknown error") }
-    99|  end
-   100|
-   101|  return { ok = true, svg_path = output_path }
-   102|end
-   103|
-   104|--- Render an SVG file inline in the terminal.
-   105|--- Returns { ok = true, method = "..." } or { ok = false, error = "..." }
-   106|function M.render_file(filepath)
-   107|  if not filepath or not vim.fn.filereadable(filepath) then
-   108|    return { ok = false, error = "File not found: " .. tostring(filepath) }
-   109|  end
-   110|
-   111|  local cap = M.detect_capability()
-   112|
-   113|  if cap == "kitty" then
-   114|    -- Use kitty +kitten icat
-   115|    local result = vim.fn.system({ "kitty", "+kitten", "icat", filepath })
-   116|    if vim.v.shell_error == 0 then
-   117|      return { ok = true, method = "kitty" }
-   118|    else
-   119|      return { ok = false, error = "kitty icat failed: " .. (result or "") }
-   120|    end
-   121|  elseif cap == "chafa" then
-   122|    -- Convert SVG to PNG first, then render via chafa
-   123|    local tmp_png = os.tmpname() .. ".png"
-   124|    -- Try converting with ImageMagick or rsvg-convert
-   125|    local converter = vim.fn.executable("rsvg-convert") == 1 and "rsvg-convert" or nil
-   126|    converter = converter or (vim.fn.executable("convert") == 1 and "convert" or nil)
-   127|
-   128|    if converter == "rsvg-convert" then
-   129|      vim.fn.system({ "rsvg-convert", filepath, "-o", tmp_png })
-   130|    elseif converter == "convert" then
-   131|      vim.fn.system({ "convert", filepath, tmp_png })
-   132|    else
-   133|      pcall(os.remove, tmp_png)
-   134|      -- Try direct SVG rendering (chafa supports SVG since v0.8+)
-   135|      vim.fn.system({ "chafa", filepath })
-   136|      if vim.v.shell_error == 0 then
-   137|        return { ok = true, method = "chafa" }
-   138|      end
-   139|      return { ok = false, error = "Neither rsvg-convert nor ImageMagick found for SVG→PNG conversion" }
-   140|    end
-   141|
-   142|    -- Render via chafa
-   143|    local result = vim.fn.system({ "chafa", tmp_png })
-   144|    pcall(os.remove, tmp_png)
-   145|    if vim.v.shell_error == 0 then
-   146|      return { ok = true, method = "chafa" }
-   147|    else
-   148|      return { ok = false, error = "chafa failed: " .. (result or "") }
-   149|    end
-   150|  else
-   151|    -- sixel or none: not supported
-   152|    return {
-   153|      ok = false,
-   154|      error = "Inline rendering not supported. Use :MermaidPreview to open in browser.",
-   155|      method = cap,
-   156|    }
-   157|  end
-   158|end
-   159|
-   160|--- Render Mermaid source text inline in the terminal.
-   161|--- Combines generate_svg + render_file.
-   162|function M.render_source(content)
-   163|  local svg = M.generate_svg(content)
-   164|  if not svg.ok then return svg end
-   165|
-   166|  local result = M.render_file(svg.svg_path)
-   167|  pcall(os.remove, svg.svg_path)
-   168|  return result
-   169|end
-   170|
-   171|--- Check if inline rendering is available at all
-   172|function M.is_available()
-   173|  return M.detect_capability() ~= "none"
-   174|end
-   175|
-   176|return M
-   177|
+--- mermaid render: render diagrams inline in the terminal
+--
+-- Supports multiple terminal capabilities:
+--   kitty:  Kitty terminal image protocol (icat)
+--   chafa:  ASCII/ANSI art via chafa CLI
+--   sixel:  Sixel graphics (if available)
+--   none:   Fallback — no inline rendering
+--
+-- Detection logic:
+--   1. Check $KITTY_WINDOW_ID for Kitty protocol
+--   2. Check $TERM_PROGRAM for iTerm2
+--   3. Check $TERM for "sixel" or "xterm" (best-effort)
+--   4. Check if `chafa` is installed
+--   5. Fallback to "none" (URL-only)
+local M = {}
+
+--- Detect what terminal rendering capability is available
+function M.detect_capability()
+  local env = vim.fn.environ()
+
+  -- Kitty protocol (most reliable)
+  if vim.fn.executable("kitty") == 1 and env["KITTY_WINDOW_ID"] ~= vim.NIL then
+    return "kitty"
+  end
+
+  -- iTerm2
+  if env["TERM_PROGRAM"] == "iTerm.app" then
+    return "iterm2"
+  end
+
+  -- Sixel
+  local term = env["TERM"] or ""
+  if term:match("sixel") then
+    return "sixel"
+  end
+
+  -- chafa (universal ASCII/ANSI art)
+  if vim.fn.executable("chafa") == 1 then
+    return "chafa"
+  end
+
+  -- No capability found
+  return "none"
+end
+
+--- Format a human-readable label for the capability
+function M.capability_label(cap)
+  local labels = {
+    kitty  = "Kitty image protocol",
+    iterm2 = "iTerm2 image protocol",
+    sixel  = "Sixel graphics",
+    chafa  = "chafa (ASCII/ANSI art)",
+    none   = "None (URL only)",
+  }
+  return labels[cap] or "Unknown"
+end
+
+--- Generate SVG using mmdc from Mermaid source text.
+--- Theme is derived from Neovim's background setting for terminal render.
+--- Returns { ok = true, svg_path = "..." } or { ok = false, error = "..." }
+function M.generate_svg(content, output_path)
+  output_path = output_path or os.tmpname() .. ".svg"
+
+  local cmd = "mmdc"
+  if vim.fn.executable(cmd) == 0 then
+    return { ok = false, error = "mmdc not found. Install @mermaid-js/mermaid-cli." }
+  end
+
+  -- Map Neovim background to mermaid theme: dark → "dark", light → "default"
+  local mmdc_theme = vim.o.background == "dark" and "dark" or "default"
+
+  local tmp_input = os.tmpname() .. ".mmd"
+  local input_f = io.open(tmp_input, "w")
+  if input_f then
+    input_f:write(content)
+    input_f:close()
+  else
+    return { ok = false, error = "Failed to write temp file" }
+  end
+
+  local result = vim.fn.system({ cmd, "-i", tmp_input, "-o", output_path, "--theme", mmdc_theme })
+  local exit_code = vim.v.shell_error
+
+  pcall(os.remove, tmp_input)
+
+  if exit_code ~= 0 then
+    pcall(os.remove, output_path)
+    return { ok = false, error = "mmdc failed: " .. (result or "unknown error") }
+  end
+
+  return { ok = true, svg_path = output_path }
+end
+
+--- Render an SVG file inline in the terminal.
+--- Returns { ok = true, method = "..." } or { ok = false, error = "..." }
+function M.render_file(filepath)
+  if not filepath or not vim.fn.filereadable(filepath) then
+    return { ok = false, error = "File not found: " .. tostring(filepath) }
+  end
+
+  local cap = M.detect_capability()
+
+  if cap == "kitty" then
+    -- Use kitty +kitten icat
+    local result = vim.fn.system({ "kitty", "+kitten", "icat", filepath })
+    if vim.v.shell_error == 0 then
+      return { ok = true, method = "kitty" }
+    else
+      return { ok = false, error = "kitty icat failed: " .. (result or "") }
+    end
+  elseif cap == "chafa" then
+    -- Convert SVG to PNG first, then render via chafa
+    local tmp_png = os.tmpname() .. ".png"
+    -- Try converting with ImageMagick or rsvg-convert
+    local converter = vim.fn.executable("rsvg-convert") == 1 and "rsvg-convert" or nil
+    converter = converter or (vim.fn.executable("convert") == 1 and "convert" or nil)
+
+    if converter == "rsvg-convert" then
+      vim.fn.system({ "rsvg-convert", filepath, "-o", tmp_png })
+    elseif converter == "convert" then
+      vim.fn.system({ "convert", filepath, tmp_png })
+    else
+      pcall(os.remove, tmp_png)
+      -- Try direct SVG rendering (chafa supports SVG since v0.8+)
+      vim.fn.system({ "chafa", filepath })
+      if vim.v.shell_error == 0 then
+        return { ok = true, method = "chafa" }
+      end
+      return { ok = false, error = "Neither rsvg-convert nor ImageMagick found for SVG→PNG conversion" }
+    end
+
+    -- Render via chafa
+    local result = vim.fn.system({ "chafa", tmp_png })
+    pcall(os.remove, tmp_png)
+    if vim.v.shell_error == 0 then
+      return { ok = true, method = "chafa" }
+    else
+      return { ok = false, error = "chafa failed: " .. (result or "") }
+    end
+  else
+    -- sixel or none: not supported
+    return {
+      ok = false,
+      error = "Inline rendering not supported. Use :MermaidPreview to open in browser.",
+      method = cap,
+    }
+  end
+end
+
+--- Render Mermaid source text inline in the terminal.
+--- Combines generate_svg + render_file.
+function M.render_source(content)
+  local svg = M.generate_svg(content)
+  if not svg.ok then return svg end
+
+  local result = M.render_file(svg.svg_path)
+  pcall(os.remove, svg.svg_path)
+  return result
+end
+
+--- Check if inline rendering is available at all
+function M.is_available()
+  return M.detect_capability() ~= "none"
+end
+
+return M

--- a/lua/mermaid/server.lua
+++ b/lua/mermaid/server.lua
@@ -1,390 +1,382 @@
-     1|local M = {}
-     2|local uv = vim.loop
-     3|
-     4|--- MIME type lookup table for static files
-     5|local MIME_TYPES = {
-     6|  html = "text/html",
-     7|  htm = "text/html",
-     8|  css = "text/css",
-     9|  js = "application/javascript",
-    10|  mjs = "application/javascript",
-    11|  svg = "image/svg+xml",
-    12|  png = "image/png",
-    13|  ico = "image/x-icon",
-    14|  json = "application/json",
-    15|  txt = "text/plain",
-    16|}
-    17|
-    18|--- Parse an HTTP request line and headers from a raw buffer.
-    19|--- Returns {method, path, headers} or nil on parse failure.
-    20|local function parse_request(data)
-    21|  local header_end = data:find("\r\n\r\n", 1, true)
-    22|  if not header_end then return nil end
-    23|
-    24|  local raw_headers = data:sub(1, header_end - 1)
-    25|  local lines = {}
-    26|  for line in raw_headers:gmatch("[^\r\n]+") do
-    27|    lines[#lines + 1] = line
-    28|  end
-    29|
-    30|  if #lines == 0 then return nil end
-    31|
-    32|  local method, path = lines[1]:match("^(%w+)%s+(%S+)%s+HTTP")
-    33|  if not method or not path then return nil end
-    34|
-    35|  -- Parse header key-value pairs
-    36|  local headers = {}
-    37|  for i = 2, #lines do
-    38|    local key, value = lines[i]:match("^([%w%-]+):%s*(.+)")
-    39|    if key then headers[key:lower()] = value end
-    40|  end
-    41|
-    42|  return { method = method, path = path, headers = headers }
-    43|end
-    44|
-    45|--- Build an HTTP response string
-    46|local function build_response(status, body, content_type, extra_headers)
-    47|  local status_text = {
-    48|    [200] = "OK",
-    49|    [404] = "Not Found",
-    50|    [500] = "Internal Server Error",
-    51|  }
-    52|  local lines = {
-    53|    "HTTP/1.1 " .. status .. " " .. (status_text[status] or ""),
-    54|    "Content-Type: " .. (content_type or "text/plain"),
-    55|    "Content-Length: " .. #body,
-    56|    "Connection: close",
-    57|  }
-    58|  if extra_headers then
-    59|    for _, h in ipairs(extra_headers) do
-    60|      lines[#lines + 1] = h
-    61|    end
-    62|  end
-    63|  lines[#lines + 1] = ""
-    64|  lines[#lines + 1] = body
-    65|  return table.concat(lines, "\r\n")
-    66|end
-    67|
-    68|--- Send an error response to the client
-    69|local function send_error(client, status, message, content_type)
-    70|  local response = build_response(status, message, content_type or "text/plain")
-    71|  client:write(response, function() client:close() end)
-    72|end
-    73|
-    74|--- Return the plugin root directory
-    75|local function get_plugin_root()
-    76|  local script_path = debug.getinfo(1, "S").source:sub(2)
-    77|  return vim.fn.fnamemodify(script_path, ":h:h:h")
-    78|end
-    79|
-    80|--------------------------------------------------------------------
-    81|-- Route Handlers
-    82|--------------------------------------------------------------------
-    83|
-    84|--- Handle the SSE event stream endpoint
-    85|local function handle_sse(client, _req)
-    86|  -- Must schedule for vim.fn.json_encode
-    87|  vim.schedule(function()
-    88|    local headers = "HTTP/1.1 200 OK\r\n" ..
-    89|      "Content-Type: text/event-stream\r\n" ..
-    90|      "Cache-Control: no-cache\r\n" ..
-    91|      "Connection: keep-alive\r\n\r\n"
-    92|    client:write(headers)
-    93|
-    94|    -- Send initial content
-    95|    local safe_content = vim.fn.json_encode(M.current_content)
-    96|    client:write("data: " .. safe_content .. "\n\n")
-    97|
-    98|    -- Register client for broadcasts
-    99|    M.clients[client] = true
-   100|
-   101|    -- Keep connection alive; listen for close
-   102|    client:read_start(function(err, chunk)
-   103|      if err or not chunk then
-   104|        M.clients[client] = nil
-   105|        if not client:is_closing() then client:close() end
-   106|      end
-   107|      -- Ignore inbound data on SSE connection
-   108|    end)
-   109|  end)
-   110|end
-   111|
-   112|--- Handle the index page and /content fallback
-   113|local function handle_root(client, _req, path)
-   114|  if path == "/" or path == "/index.html" then
-   115|    local html = M.get_html_template()
-   116|    if html then
-   117|      client:write(build_response(200, html, MIME_TYPES.html), function()
-   118|        client:close()
-   119|      end)
-   120|    else
-   121|      send_error(client, 500, "Failed to load template", MIME_TYPES.plain)
-   122|    end
-   123|  elseif path == "/content" then
-   124|    client:write(build_response(200, M.current_content, MIME_TYPES.plain), function()
-   125|      client:close()
-   126|    end)
-   127|  else
-   128|    send_error(client, 404, "Not Found")
-   129|  end
-   130|end
-   131|
-   132|--- Handle static file requests (CSS, JS, etc.)
-   133|local function handle_static(client, _req, path)
-   134|  local filename = path:sub(2) -- strip leading /
-   135|  if filename == "" then filename = "index.html" end
-   136|
-   137|  -- Security: prevent directory traversal
-   138|  if filename:find("%.%.") then
-   139|    send_error(client, 404, "Not Found")
-   140|    return
-   141|  end
-   142|
-   143|  local f = io.open(get_plugin_root() .. "/static/" .. filename, "rb")
-   144|  if not f then
-   145|    send_error(client, 404, "Not Found")
-   146|    return
-   147|  end
-   148|
-   149|  local body = f:read("*a") or ""
-   150|  f:close()
-   151|
-   152|  -- Determine MIME type from extension
-   153|  local ext = filename:match("%.([%w]+)$")
-   154|  local content_type = MIME_TYPES[ext] or MIME_TYPES.plain
-   155|
-   156|  client:write(build_response(200, body, content_type), function()
-   157|    client:close()
-   158|  end)
-   159|end
-   160|
-   161|--------------------------------------------------------------------
-   162|-- Public API
-   163|--------------------------------------------------------------------
-   164|
-   165|M.port = nil
-   166|M.server = nil
-   167|M.current_content = "graph TD\nA[Loading...]"
-   168|M.clients = {}
-   169|M.monitor_timer = nil
-   170|M.theme_mode = "light"  -- "light" or "dark"
-   171|M._test_mode = false     -- Set true in tests to skip idle monitor
-   172|
-   173|--- Broadcast updated content to all connected SSE clients
-   174|function M.broadcast(content)
-   175|  local safe_content = vim.fn.json_encode(content)
-   176|  local message = "data: " .. safe_content .. "\n\n"
-   177|
-   178|  for client, _ in pairs(M.clients) do
-   179|    if not client:is_closing() then
-   180|      client:write(message)
-   181|    end
-   182|  end
-   183|end
-   184|
-   185|--- Set the theme mode (light/dark) for the preview page
-   186|function M.set_theme_mode(mode)
-   187|  M.theme_mode = (mode == "dark") and "dark" or "light"
-   188|end
-   189|
-   190|--- Update the current diagram content and broadcast changes
-   191|function M.set_content(content)
-   192|  if M.current_content ~= content then
-   193|    M.current_content = content
-   194|    M.broadcast(content)
-   195|  end
-   196|end
-   197|
-   198|--- Start the HTTP server, return the assigned port
-   199|function M.start_server()
-   200|  if M.server then return M.port end
-   201|
-   202|  M.server = uv.new_tcp()
-   203|  M.server:bind("127.0.0.1", 0)
-   204|
-   205|  local addr = M.server:getsockname()
-   206|  M.port = addr.port
-   207|
-   208|  M.server:listen(128, function(err)
-   209|    if err then
-   210|      vim.schedule(function()
-   211|        vim.notify("Mermaid: Listen error: " .. tostring(err), vim.log.levels.ERROR)
-   212|      end)
-   213|      return
-   214|    end
-   215|    M.start_monitoring()
-   216|
-   217|    local client = uv.new_tcp()
-   218|    M.server:accept(client)
-   219|
-   220|    -- Optional: set TCP keepalive
-   221|    client:keepalive(true, 30)
-   222|
-   223|    local data_buffer = ""
-   224|    local req_timer = uv.new_timer()
-   225|
-   226|    -- Request timeout: close connection if headers don't arrive within 10s
-   227|    req_timer:start(10000, 0, function()
-   228|      if not client:is_closing() then client:close() end
-   229|    end)
-   230|
-   231|    client:read_start(function(read_err, chunk)
-   232|      if read_err or not chunk then
-   233|        if not req_timer:is_closing() then req_timer:close() end
-   234|        if not client:is_closing() then client:close() end
-   235|        return
-   236|      end
-   237|
-   238|      data_buffer = data_buffer .. chunk
-   239|      local req = parse_request(data_buffer)
-   240|
-   241|      if req then
-   242|        -- Stop the request timeout; we have a complete request
-   243|        if not req_timer:is_closing() then
-   244|          req_timer:stop()
-   245|          req_timer:close()
-   246|        end
-   247|
-   248|        M.last_access = os.time()
-   249|
-   250|        -- Route dispatch
-   251|        if req.path == "/events" then
-   252|          handle_sse(client, req)
-   253|        elseif req.path:match("^/css/") or req.path:match("^/js/") then
-   254|          handle_static(client, req, req.path)
-   255|        elseif req.path == "/" or req.path == "/index.html" or req.path == "/content" then
-   256|          handle_root(client, req, req.path)
-   257|        else
-   258|          handle_static(client, req, req.path)
-   259|        end
-   260|      end
-   261|    end)
-   262|  end)
-   263|
-   264|  return M.port
-   265|end
-   266|
-   267|--- Start the idle monitor (auto-close server after 20s with no clients)
-   268|function M.start_monitoring()
-   269|  if M.monitor_timer or M._test_mode then return end
-   270|
-   271|  local idle_since = nil
-   272|  M.monitor_timer = uv.new_timer()
-   273|
-   274|  M.monitor_timer:start(2000, 2000, vim.schedule_wrap(function()
-   275|    if not M.server then
-   276|      M.stop_server()
-   277|      return
-   278|    end
-   279|
-   280|    local client_count = 0
-   281|    for _, _ in pairs(M.clients) do client_count = client_count + 1 end
-   282|
-   283|    if client_count == 0 then
-   284|      if not idle_since then
-   285|        idle_since = os.time()
-   286|      elseif os.time() - idle_since > 20 then
-   287|        vim.notify("Mermaid: Preview closed (no active clients)", vim.log.levels.INFO)
-   288|        M.stop_server()
-   289|      end
-   290|    else
-   291|      idle_since = nil
-   292|    end
-   293|  end))
-   294|end
-   295|
-   296|--- Stop the server and clean up all resources
-   297|function M.stop_server()
-   298|  -- Close all SSE clients
-   299|  for client, _ in pairs(M.clients) do
-   300|    if not client:is_closing() then client:close() end
-   301|  end
-   302|  M.clients = {}
-   303|
-   304|  -- Stop monitor timer
-   305|  if M.monitor_timer then
-   306|    M.monitor_timer:stop()
-   307|    if not M.monitor_timer:is_closing() then
-   308|      M.monitor_timer:close()
-   309|    end
-   310|    M.monitor_timer = nil
-   311|  end
-   312|
-   313|  -- Close server socket
-   314|  if M.server then
-   315|    if not M.server:is_closing() then
-   316|      M.server:close()
-   317|    end
-   318|    M.server = nil
-   319|    M.port = nil
-   320|  end
-   321|<<<<<<< HEAD
-   322|end
-   323|
-   324|--- Get the effective theme mode (light/dark) for HTML preview.
-   325|--- Derived from the theme name itself, NOT Neovim's background.
-   326|--- This ensures the page CSS matches the chosen renderer theme.
-   327|function M.get_effective_theme_mode()
-   328|  local theme = require("mermaid").config.preview.theme
-   329|  -- Explicit dark themes (mermaid.js + beautiful-mermaid)
-   330|  if theme:match("dark") and not theme:match("light") then
-   331|    return "dark"
-   332|  end
-   333|  if theme:match("night") and not theme:match("light") then
-   334|    return "dark"
-   335|  end
-   336|  if theme:match("storm") then return "dark" end
-   337|  if theme:match("dracula") then return "dark" end
-   338|  if theme:match("mocha") then return "dark" end
-   339|  if theme == "nord" then return "dark" end
-   340|  return "light"
-   341|=======
-   342|>>>>>>> origin/main
-   343|end
-   344|
-   345|--- Build the HTML template with injected renderer scripts
-   346|function M.get_html_template()
-   347|  local mermaid_config = require("mermaid").config
-   348|  local renderer = mermaid_config.preview.renderer
-   349|  local theme = mermaid_config.preview.theme
-   350|
-   351|  local scripts
-   352|  if renderer == "beautiful-mermaid" then
-   353|    scripts = [[
-   354|  <script type="module">
-   355|    import { renderMermaidSVG, THEMES, DEFAULTS } from 'https://esm.sh/beautiful-mermaid@1.1.3?exports=renderMermaidSVG,THEMES,DEFAULTS';
-   356|    window.renderMermaidSVG = renderMermaidSVG;
-   357|    window.BEAUTIFUL_THEMES = THEMES;
-   358|    window.BEAUTIFUL_DEFAULTS = DEFAULTS;
-   359|    window.rendererReady = true;
-   360|  </script>]]
-   361|  else
-   362|    scripts = [[
-   363|  <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
-   364|  <script>
-   365|    window.addEventListener('load', () => {
-   366|        mermaid.initialize({ startOnLoad: false, theme: ']] .. theme .. [[' });
-   367|        window.rendererReady = true;
-   368|    });
-   369|  </script>]]
-   370|  end
-   371|
-   372|  local f = io.open(get_plugin_root() .. "/static/index.html", "r")
-   373|  if not f then return nil end
-   374|  local template = f:read("*a")
-   375|  f:close()
-   376|
-   377|  template = template:gsub("{{RENDERER}}", renderer)
-   378|  template = template:gsub("{{THEME}}", theme)
-   379|<<<<<<< HEAD
-   380|  template = template:gsub("{{THEME_MODE}}", M.get_effective_theme_mode())
-   381|=======
-   382|  template = template:gsub("{{THEME_MODE}}", M.theme_mode)
-   383|>>>>>>> origin/main
-   384|  template = template:gsub("{{SCRIPTS}}", scripts)
-   385|
-   386|  return template
-   387|end
-   388|
-   389|return M
-   390|
+local M = {}
+local uv = vim.loop
+
+--- MIME type lookup table for static files
+local MIME_TYPES = {
+  html = "text/html",
+  htm = "text/html",
+  css = "text/css",
+  js = "application/javascript",
+  mjs = "application/javascript",
+  svg = "image/svg+xml",
+  png = "image/png",
+  ico = "image/x-icon",
+  json = "application/json",
+  txt = "text/plain",
+}
+
+--- Parse an HTTP request line and headers from a raw buffer.
+--- Returns {method, path, headers} or nil on parse failure.
+local function parse_request(data)
+  local header_end = data:find("\r\n\r\n", 1, true)
+  if not header_end then return nil end
+
+  local raw_headers = data:sub(1, header_end - 1)
+  local lines = {}
+  for line in raw_headers:gmatch("[^\r\n]+") do
+    lines[#lines + 1] = line
+  end
+
+  if #lines == 0 then return nil end
+
+  local method, path = lines[1]:match("^(%w+)%s+(%S+)%s+HTTP")
+  if not method or not path then return nil end
+
+  -- Parse header key-value pairs
+  local headers = {}
+  for i = 2, #lines do
+    local key, value = lines[i]:match("^([%w%-]+):%s*(.+)")
+    if key then headers[key:lower()] = value end
+  end
+
+  return { method = method, path = path, headers = headers }
+end
+
+--- Build an HTTP response string
+local function build_response(status, body, content_type, extra_headers)
+  local status_text = {
+    [200] = "OK",
+    [404] = "Not Found",
+    [500] = "Internal Server Error",
+  }
+  local lines = {
+    "HTTP/1.1 " .. status .. " " .. (status_text[status] or ""),
+    "Content-Type: " .. (content_type or "text/plain"),
+    "Content-Length: " .. #body,
+    "Connection: close",
+  }
+  if extra_headers then
+    for _, h in ipairs(extra_headers) do
+      lines[#lines + 1] = h
+    end
+  end
+  lines[#lines + 1] = ""
+  lines[#lines + 1] = body
+  return table.concat(lines, "\r\n")
+end
+
+--- Send an error response to the client
+local function send_error(client, status, message, content_type)
+  local response = build_response(status, message, content_type or "text/plain")
+  client:write(response, function() client:close() end)
+end
+
+--- Return the plugin root directory
+local function get_plugin_root()
+  local script_path = debug.getinfo(1, "S").source:sub(2)
+  return vim.fn.fnamemodify(script_path, ":h:h:h")
+end
+
+--------------------------------------------------------------------
+-- Route Handlers
+--------------------------------------------------------------------
+
+--- Handle the SSE event stream endpoint
+local function handle_sse(client, _req)
+  -- Must schedule for vim.fn.json_encode
+  vim.schedule(function()
+    local headers = "HTTP/1.1 200 OK\r\n" ..
+      "Content-Type: text/event-stream\r\n" ..
+      "Cache-Control: no-cache\r\n" ..
+      "Connection: keep-alive\r\n\r\n"
+    client:write(headers)
+
+    -- Send initial content
+    local safe_content = vim.fn.json_encode(M.current_content)
+    client:write("data: " .. safe_content .. "\n\n")
+
+    -- Register client for broadcasts
+    M.clients[client] = true
+
+    -- Keep connection alive; listen for close
+    client:read_start(function(err, chunk)
+      if err or not chunk then
+        M.clients[client] = nil
+        if not client:is_closing() then client:close() end
+      end
+      -- Ignore inbound data on SSE connection
+    end)
+  end)
+end
+
+--- Handle the index page and /content fallback
+local function handle_root(client, _req, path)
+  if path == "/" or path == "/index.html" then
+    local html = M.get_html_template()
+    if html then
+      client:write(build_response(200, html, MIME_TYPES.html), function()
+        client:close()
+      end)
+    else
+      send_error(client, 500, "Failed to load template", MIME_TYPES.plain)
+    end
+  elseif path == "/content" then
+    client:write(build_response(200, M.current_content, MIME_TYPES.plain), function()
+      client:close()
+    end)
+  else
+    send_error(client, 404, "Not Found")
+  end
+end
+
+--- Handle static file requests (CSS, JS, etc.)
+local function handle_static(client, _req, path)
+  local filename = path:sub(2) -- strip leading /
+  if filename == "" then filename = "index.html" end
+
+  -- Security: prevent directory traversal
+  if filename:find("%.%.") then
+    send_error(client, 404, "Not Found")
+    return
+  end
+
+  local f = io.open(get_plugin_root() .. "/static/" .. filename, "rb")
+  if not f then
+    send_error(client, 404, "Not Found")
+    return
+  end
+
+  local body = f:read("*a") or ""
+  f:close()
+
+  -- Determine MIME type from extension
+  local ext = filename:match("%.([%w]+)$")
+  local content_type = MIME_TYPES[ext] or MIME_TYPES.plain
+
+  client:write(build_response(200, body, content_type), function()
+    client:close()
+  end)
+end
+
+--------------------------------------------------------------------
+-- Public API
+--------------------------------------------------------------------
+
+M.port = nil
+M.server = nil
+M.current_content = "graph TD\nA[Loading...]"
+M.clients = {}
+M.monitor_timer = nil
+M.theme_mode = "light"  -- "light" or "dark"
+M._test_mode = false     -- Set true in tests to skip idle monitor
+
+--- Broadcast updated content to all connected SSE clients
+function M.broadcast(content)
+  local safe_content = vim.fn.json_encode(content)
+  local message = "data: " .. safe_content .. "\n\n"
+
+  for client, _ in pairs(M.clients) do
+    if not client:is_closing() then
+      client:write(message)
+    end
+  end
+end
+
+--- Set the theme mode (light/dark) for the preview page
+function M.set_theme_mode(mode)
+  M.theme_mode = (mode == "dark") and "dark" or "light"
+end
+
+--- Update the current diagram content and broadcast changes
+function M.set_content(content)
+  if M.current_content ~= content then
+    M.current_content = content
+    M.broadcast(content)
+  end
+end
+
+--- Start the HTTP server, return the assigned port
+function M.start_server()
+  if M.server then return M.port end
+
+  M.server = uv.new_tcp()
+  M.server:bind("127.0.0.1", 0)
+
+  local addr = M.server:getsockname()
+  M.port = addr.port
+
+  M.server:listen(128, function(err)
+    if err then
+      vim.schedule(function()
+        vim.notify("Mermaid: Listen error: " .. tostring(err), vim.log.levels.ERROR)
+      end)
+      return
+    end
+    M.start_monitoring()
+
+    local client = uv.new_tcp()
+    M.server:accept(client)
+
+    -- Optional: set TCP keepalive
+    client:keepalive(true, 30)
+
+    local data_buffer = ""
+    local req_timer = uv.new_timer()
+
+    -- Request timeout: close connection if headers don't arrive within 10s
+    req_timer:start(10000, 0, function()
+      if not client:is_closing() then client:close() end
+    end)
+
+    client:read_start(function(read_err, chunk)
+      if read_err or not chunk then
+        if not req_timer:is_closing() then req_timer:close() end
+        if not client:is_closing() then client:close() end
+        return
+      end
+
+      data_buffer = data_buffer .. chunk
+      local req = parse_request(data_buffer)
+
+      if req then
+        -- Stop the request timeout; we have a complete request
+        if not req_timer:is_closing() then
+          req_timer:stop()
+          req_timer:close()
+        end
+
+        M.last_access = os.time()
+
+        -- Route dispatch
+        if req.path == "/events" then
+          handle_sse(client, req)
+        elseif req.path:match("^/css/") or req.path:match("^/js/") then
+          handle_static(client, req, req.path)
+        elseif req.path == "/" or req.path == "/index.html" or req.path == "/content" then
+          handle_root(client, req, req.path)
+        else
+          handle_static(client, req, req.path)
+        end
+      end
+    end)
+  end)
+
+  return M.port
+end
+
+--- Start the idle monitor (auto-close server after 20s with no clients)
+function M.start_monitoring()
+  if M.monitor_timer or M._test_mode then return end
+
+  local idle_since = nil
+  M.monitor_timer = uv.new_timer()
+
+  M.monitor_timer:start(2000, 2000, vim.schedule_wrap(function()
+    if not M.server then
+      M.stop_server()
+      return
+    end
+
+    local client_count = 0
+    for _, _ in pairs(M.clients) do client_count = client_count + 1 end
+
+    if client_count == 0 then
+      if not idle_since then
+        idle_since = os.time()
+      elseif os.time() - idle_since > 20 then
+        vim.notify("Mermaid: Preview closed (no active clients)", vim.log.levels.INFO)
+        M.stop_server()
+      end
+    else
+      idle_since = nil
+    end
+  end))
+end
+
+--- Stop the server and clean up all resources
+function M.stop_server()
+  -- Close all SSE clients
+  for client, _ in pairs(M.clients) do
+    if not client:is_closing() then client:close() end
+  end
+  M.clients = {}
+
+  -- Stop monitor timer
+  if M.monitor_timer then
+    M.monitor_timer:stop()
+    if not M.monitor_timer:is_closing() then
+      M.monitor_timer:close()
+    end
+    M.monitor_timer = nil
+  end
+
+  -- Close server socket
+  if M.server then
+    if not M.server:is_closing() then
+      M.server:close()
+    end
+    M.server = nil
+    M.port = nil
+  end
+end
+
+--- Get the effective theme mode (light/dark) for HTML preview.
+--- Derived from the theme name itself, NOT Neovim's background.
+--- This ensures the page CSS matches the chosen renderer theme.
+function M.get_effective_theme_mode()
+  local theme = require("mermaid").config.preview.theme
+  -- Explicit dark themes (mermaid.js + beautiful-mermaid)
+  if theme:match("dark") and not theme:match("light") then
+    return "dark"
+  end
+  if theme:match("night") and not theme:match("light") then
+    return "dark"
+  end
+  if theme:match("storm") then return "dark" end
+  if theme:match("dracula") then return "dark" end
+  if theme:match("mocha") then return "dark" end
+  if theme == "nord" then return "dark" end
+  return "light"
+end
+
+--- Build the HTML template with injected renderer scripts
+function M.get_html_template()
+  local mermaid_config = require("mermaid").config
+  local renderer = mermaid_config.preview.renderer
+  local theme = mermaid_config.preview.theme
+
+  local scripts
+  if renderer == "beautiful-mermaid" then
+    scripts = [[
+  <script type="module">
+    import { renderMermaidSVG, THEMES, DEFAULTS } from 'https://esm.sh/beautiful-mermaid@1.1.3?exports=renderMermaidSVG,THEMES,DEFAULTS';
+    window.renderMermaidSVG = renderMermaidSVG;
+    window.BEAUTIFUL_THEMES = THEMES;
+    window.BEAUTIFUL_DEFAULTS = DEFAULTS;
+    window.rendererReady = true;
+  </script>]]
+  else
+    scripts = [[
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+  <script>
+    window.addEventListener('load', () => {
+        mermaid.initialize({ startOnLoad: false, theme: ']] .. theme .. [[' });
+        window.rendererReady = true;
+    });
+  </script>]]
+  end
+
+  local f = io.open(get_plugin_root() .. "/static/index.html", "r")
+  if not f then return nil end
+  local template = f:read("*a")
+  f:close()
+
+  template = template:gsub("{{RENDERER}}", renderer)
+  template = template:gsub("{{THEME}}", theme)
+  template = template:gsub("{{THEME_MODE}}", M.get_effective_theme_mode())
+  template = template:gsub("{{SCRIPTS}}", scripts)
+
+  return template
+end
+
+return M


### PR DESCRIPTION
## Summary

Fix CI failures on main caused by unresolved merge conflicts from PR #5 merge.

**Root cause:** When PR #5 (feat/full-overhaul-031) was merged into main, the merge committed unresolved conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) and line-number corruption in 3 Lua files.

**Symptoms:**
- Luacheck: 3 errors — `expected statement near '1'` on panel.lua, render.lua, server.lua
- Neovim nightly: `E5113: unexpected symbol near '1'` parse failures
- All other Neovim versions: tests pass but process exits with code 1

### Changes
- Strip line-number prefix (`     N|`) from all 3 files
- Resolve 6 merge conflict blocks, keeping HEAD (overhaul branch features)
  - panel.lua: `get_effective_theme_mode()` function reference
  - render.lua: theme-aware `mmdc` invocation with `--theme` flag
  - server.lua: `get_effective_theme_mode()` implementation

### Verification
- Luacheck: **0 errors, 0 warnings** ✅ (was 3 errors)
- All tests pass locally ✅