### PR TITLE
feat: auto-tag and release on merge to main (NG-6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,33 @@ jobs:
           nvim --headless -u tests/minimal_init.lua \
             -c "PlenaryBustedDirectory tests/ { minimal_init = 'tests/minimal_init.lua' }"
 
+  auto-tag:
+    name: Auto Tag
+    if: github.ref == 'refs/heads/main'
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Bump version and push tag
+        run: |
+          LATEST=$(git tag --sort=-v:refname | grep '^v' | head -1 || echo "v0.0.0")
+          # Extract major.minor.patch and bump patch
+          RAW=$(echo "$LATEST" | sed 's/^v//')
+          MAJOR=$(echo "$RAW" | cut -d. -f1)
+          MINOR=$(echo "$RAW" | cut -d. -f2)
+          PATCH=$(echo "$RAW" | cut -d. -f3)
+          NEXT="v${MAJOR}.${MINOR}.$((PATCH + 1))"
+          echo "Latest: $LATEST → Next: $NEXT"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$NEXT"
+          git push origin "$NEXT"
+
   release:
-    name: Release (tag push only)
+    name: Release
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [lint, test]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add automatic semver tagging on merge to main after CI passes.

### Changes
- **New `auto-tag` job**: runs on push to `main` after `lint` + `test` pass
  - Reads latest `v*` tag, bumps patch version
  - If no tags exist, starts at `v0.0.1`
  - Pushes tag → triggers existing `release` job
  
### Workflow
```
PR merge to main
  → lint ✅
  → test ✅ (all Neovim versions)
  → auto-tag creates vX.Y.(Z+1)
    → tag push triggers release job
      → GitHub Release created with auto-generated notes
```

### Tag format
Semantic versioning: `v{major}.{minor}.{patch}` — industry standard for Neovim plugins.