### PR TITLE
fix: handle no-existing-tags case in auto-tag job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,8 @@ jobs:
 
       - name: Bump version and push tag
         run: |
-          LATEST=$(git tag --sort=-v:refname | grep '^v' | head -1 || echo "v0.0.0")
+          LATEST=$(git tag --sort=-v:refname | grep '^v' | head -1)
+          LATEST=${LATEST:-v0.0.0}
           # Extract major.minor.patch and bump patch
           RAW=$(echo "$LATEST" | sed 's/^v//')
           MAJOR=$(echo "$RAW" | cut -d. -f1)


### PR DESCRIPTION
## Summary

Fix auto-tag job failing when no existing tags are present.

**Root cause:** `git tag | grep | head || echo` masked grep's exit code (1) with head's success (0), so the fallback never fired. `LATEST` was empty, producing invalid tag `v..1`.

**Fix:** Use shell parameter expansion `${LATEST:-v0.0.0}` instead.