### PR TITLE
fix: add contents:write permission for auto-tag push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   lint:
     name: Luacheck


### PR DESCRIPTION
## Summary

auto-tag job failed with 403 when pushing tags. GITHUB_TOKEN defaults to read-only for contents.

**Fix:** Add `permissions: contents: write` to workflow.