### PR TITLE
fix: prevent formatter from splitting class assignment operator (:::)

### DIFF
--- a/lua/mermaid/format.lua
+++ b/lua/mermaid/format.lua
@@ -127,6 +127,7 @@ local function pad_mermaid_tokens(line)
     "%=%=",          -- == (Thick link)
 
     -- Misc
+    ":::",          -- Class assignment (must be before bare :)
     ":",            -- Colon (often splits label)
   }
 
@@ -146,6 +147,9 @@ local function pad_mermaid_tokens(line)
   -- Remove space before colon when it follows a word character
   -- (sequence diagram labels: `Bob: Hello`, not `Bob : Hello`)
   line = line:gsub("(%w) :", "%1:")
+
+  -- Remove spaces around class assignment operator :::
+  line = line:gsub("%s*:::%s*", ":::")
 
   return line
 end

--- a/tests/format_edge_spec.lua
+++ b/tests/format_edge_spec.lua
@@ -183,6 +183,21 @@ describe("mermaid format — edge cases v2", function()
     end)
   end)
 
+  describe("class assignment operator", function()
+    it("does not split the ::: class assignment operator", function()
+      local result = format_text({
+        "flowchart TD",
+        "A:::myClass --> B:::otherClass",
+        "C:::class1-->D:::class2",
+        "E ::: class3",
+      })
+      assert.are.same("flowchart TD", result[1])
+      assert.are.same("  A:::myClass --> B:::otherClass", result[2])
+      assert.are.same("  C:::class1 --> D:::class2", result[3])
+      assert.are.same("  E:::class3", result[4])
+    end)
+  end)
+
   describe("empty buffer", function()
     it("handles completely empty buffer gracefully", function()
       local buf = vim.api.nvim_create_buf(false, true)


### PR DESCRIPTION
Hi @kevalin,

Cool plugin! I ran across a bug while running the formatter.

In flowchart diagrams, the class assignment operator `:::` is used to bind styles to a node. 

Currently, the formatter stashes single colons (`:`), which matches and separates the colons in `:::` into ` : : : `, breaking the diagram. 

This PR adds `:::` to the patterns list before the single colon so it is treated as a single token, and trims any spaces around it to maintain valid Mermaid syntax.

I've also added a simple test case for this to prevent regression.

I've looked through contributing.md, I don't think I need to do anything else for this PR but let me know if you think otherwise. It does mention a develop branch, but it doesn't exist.


Thanks - William.